### PR TITLE
screen onoff interface

### DIFF
--- a/app/models/concerto_hardware/player.rb
+++ b/app/models/concerto_hardware/player.rb
@@ -122,13 +122,13 @@ module ConcertoHardware
       elsif !screen_on_off_valid
         rules << "On/off rules are invalid. Edit and save the Player to fix."
       else
-        rules << "Weekdays: on at "+fmt_time(wkday_on_time)+", "+
-          "off at "+fmt_time(wkday_off_time)+"."
+        rules << "Weekdays: on at "+fmt_time(wkday_on_time, "%l:%M%P")+", "+
+          "off at "+fmt_time(wkday_off_time, "%l:%M%P")+"."
         if wknd_disable
           rules << "Weekends: off."
         else
-          rules << "Weekends: on at "+fmt_time(wknd_on_time)+", "+
-            "off at "+fmt_time(wknd_off_time)+"."
+          rules << "Weekends: on at "+fmt_time(wknd_on_time, "%l:%M%P")+", "+
+            "off at "+fmt_time(wknd_off_time, "%l:%M%P")+"."
         end
         if force_off
           rules << "Manual override: screen will be off until midnight tonight."
@@ -137,14 +137,12 @@ module ConcertoHardware
       rules
     end
 
-    def fmt_time(timeobj)
-      #timeobj.strftime("%H:%M")
+    def fmt_time(timeobj, fmt = "%H:%M")
       if !timeobj.nil?
         if timeobj.is_a?(String)
-          timeobj
-        else
-          timeobj.strftime("%l:%M%P")
+          timeobj = Time.parse(timeobj)
         end
+        timeobj.strftime(fmt)
       end
     end
 

--- a/app/views/concerto_hardware/players/_form.html.erb
+++ b/app/views/concerto_hardware/players/_form.html.erb
@@ -36,14 +36,14 @@
         <%= f.label :wkday_on_time %>
         <div class="input-prepend">
           <span class="add-on"><%= t(:at) %></span>
-          <%= f.text_field(:wkday_on_time, :maxlength => 20, :class => "time start timefield input-small", :value => @player.fmt_time(@player.wkday_on_time) || ConcertoConfig[:content_default_start_time]) %>
+          <%= f.text_field(:wkday_on_time, :maxlength => 20, :class => "time start timefield input-small", :value => @player.fmt_time(@player.wkday_on_time, "%l:%M%P") || ConcertoConfig[:content_default_start_time]) %>
         </div>
       </div>
       <div class="clearfix">
         <%= f.label :wkday_off_time %>
         <div class="input-prepend">
           <span class="add-on"><%= t(:at) %></span>
-          <%= f.text_field(:wkday_off_time, :maxlength => 20, :class => "time end timefield input-small", :value => @player.fmt_time(@player.wkday_off_time) || ConcertoConfig[:content_default_end_time]) %>
+          <%= f.text_field(:wkday_off_time, :maxlength => 20, :class => "time end timefield input-small", :value => @player.fmt_time(@player.wkday_off_time, "%l:%M%P") || ConcertoConfig[:content_default_end_time]) %>
         </div>
       </div>
     </div>
@@ -60,14 +60,14 @@
         <%= f.label :wknd_on_time %>
         <div class="input-prepend">
           <span class="add-on"><%= t(:at) %></span>
-          <%= f.text_field(:wknd_on_time, :maxlength => 20, :class => "time start timefield input-small", :value => @player.fmt_time(@player.wknd_on_time) || ConcertoConfig[:content_default_start_time]) %>
+          <%= f.text_field(:wknd_on_time, :maxlength => 20, :class => "time start timefield input-small", :value => @player.fmt_time(@player.wknd_on_time, "%l:%M%P") || ConcertoConfig[:content_default_start_time]) %>
         </div>
       </div>
       <div class="clearfix">
         <%= f.label :wknd_off_time %>
         <div class="input-prepend">
           <span class="add-on"><%= t(:at) %></span>
-          <%= f.text_field(:wknd_off_time, :maxlength => 20, :class => "time end timefield input-small", :value => @player.fmt_time(@player.wknd_off_time) || ConcertoConfig[:content_default_end_time]) %>
+          <%= f.text_field(:wknd_off_time, :maxlength => 20, :class => "time end timefield input-small", :value => @player.fmt_time(@player.wknd_off_time, "%l:%M%P") || ConcertoConfig[:content_default_end_time]) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
@mikldt this is working towards #9 but it may have severe impact on the API because I changed the time format to 12 hour since that is what the concerto timepicker uses (content add/edit timeframe).

@brzaik will still need to tweak it-- weekend inputs should be hidden if checkbox for disable on weekends is checked, time fields should be side by side, etc.
